### PR TITLE
Change our branch name preference to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,10 +279,10 @@ Query {
 
 - Use separate repositories for frontend and backend applications.
   - e.g.: repo-web, repo-mobile, and repo-api
-- Projects should follow Git flow, and have both a **master** and **dev**
+- Projects should follow Git flow, and have both a **main** and **dev**
   branch.
-  - Open source apps or small projects can use a single **master** branch.
-- Both **dev** and **master** should be protected branches.
+  - Open source apps or small projects can use a single **main** branch.
+- Both **dev** and **main** should be protected branches.
   - Status checks must pass before merging.
   - Require branches are up-to-date.
 


### PR DESCRIPTION
We would like to move towards more inclusive language where possible and one step in that process is updating our default branch names to `main` instead of `master`. This aligns with [GitHubs goals](https://github.com/github/renaming). For all new repositories, they have set `main` as the default branch name and are in the process of setting up infrastructure to help organizations move their existing repositories over to `main` as well which we will do once that is in place. 