### PR TITLE
Remove the 80 char limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ why.
 
 ## General
 
-- Use a line length of 80 characters.
 - Use camelCase when naming objects, functions, and instances.
 
 ```javascript


### PR DESCRIPTION
From our style guide:

> Don't include rules in this guide that could be covered by eslint or prettier configurations.

Prettier will attempt to keep lines around 80 characters. Sometimes it will go over and sometimes under, but it tries to keep the visual pacing consist around 80 line limits. So I think prettier's default configuration satisfies this rule, and in the interest of following our rule of not including rules in here that are covered by prettier, I vote to remove this one.

**This is a style guide change proposal and therefore requires at least half of the dev team to give an approving review**